### PR TITLE
:sparkles: Adds support for self creating 'new' addons to the repository

### DIFF
--- a/repositoryupdater/addon.py
+++ b/repositoryupdater/addon.py
@@ -107,6 +107,7 @@ class Addon:
                 'aborting...'))
             sys.exit(1)
 
+        self.ensure_addon_dir()
         self.generate_addon_config()
         self.update_static_files()
         self.generate_addon_changelog()
@@ -214,6 +215,16 @@ class Addon:
         return self.updating and (
             force or self.current_version != self.latest_version or
             self.current_commit != self.latest_commit)
+
+    def ensure_addon_dir(self):
+        """Ensure the add-on target directory exists."""
+        addon_path = os.path.join(
+            self.repository.working_dir,
+            self.repository_target
+        )
+
+        if not os.path.exists(addon_path):
+            os.mkdir(addon_path)
 
     def generate_addon_config(self):
         """Generate add-on configuration file."""


### PR DESCRIPTION
In case the add-on is updated/added for the first time, a directory for the add-on needs to be created.

This PR ensures the target directory within the add-ons repository exists before updating.