### PR TITLE
Add apparmor.txt support

### DIFF
--- a/repositoryupdater/addon.py
+++ b/repositoryupdater/addon.py
@@ -276,6 +276,7 @@ class Addon:
         self.update_static_file("icon.png")
         self.update_static_file("README.md")
         self.update_static_file("DOCS.md")
+        self.update_static_file("apparmor.txt")
 
     def update_static_file(self, file):
         """Download latest static file from add-on repository."""


### PR DESCRIPTION
# Proposed Changes

`apparmor.txt` was not being copied, resulting in the profile not being loaded.

## Related Issues

> [AppArmor.txt not being updated #16](https://github.com/hassio-addons/repository-updater/issues/16)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/