### PR TITLE
Fix to work with hidden email

### DIFF
--- a/repositoryupdater/github.py
+++ b/repositoryupdater/github.py
@@ -32,7 +32,8 @@ class GitHub(PyGitHub):
         repo = Repo.clone_from(repository.clone_url, destination, None, environ)
 
         config = repo.config_writer()
-        config.set_value("user", "email", self.get_user().email)
+        if self.get_user().email:
+            config.set_value("user", "email", self.get_user().email)
         config.set_value("user", "name", self.get_user().name)
         config.set_value("commit", "gpgsign", "false")
 


### PR DESCRIPTION
# Proposed Changes

> Allow to work with github accounts with hidden email 

## Related Issues

> repository-updater does not works with accounts which does not have public email

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/