### PR TITLE
Add support for yaml files and multiple translation files

### DIFF
--- a/action/Dockerfile
+++ b/action/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine3.13
+FROM python:3.10-alpine3.14
 
 # Setup base
 RUN \
@@ -9,8 +9,8 @@ RUN \
     && pip3 install \
         --no-cache-dir \
         --prefer-binary \
-        --find-links "https://wheels.home-assistant.io/alpine-3.13/${BUILD_ARCH}/" \
-        repository-updater==1.1.0
+        --find-links "https://wheels.home-assistant.io/alpine-3.14/${BUILD_ARCH}/" \
+        repository-updater==1.2.0
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,15 @@
-FROM python:3.9-alpine3.13
+FROM python:3.10-alpine3.14
 
 # Setup base
 RUN \
     apk add --no-cache \
-        git=2.30.2-r0 \
+        git=2.32.0-r0 \
     \
     && pip3 install \
         --no-cache-dir \
         --prefer-binary \
-        --find-links "https://wheels.home-assistant.io/alpine-3.13/${BUILD_ARCH}/" \
-        repository-updater==1.1.0
+        --find-links "https://wheels.home-assistant.io/alpine-3.14/${BUILD_ARCH}/" \
+        repository-updater==1.2.0
 
 # Entrypoint
 ENTRYPOINT ["repository-updater"]

--- a/repositoryupdater/__init__.py
+++ b/repositoryupdater/__init__.py
@@ -12,7 +12,7 @@ Home Assistant add-on repository approach.
 
 APP_NAME = "repository-updater"
 APP_FULL_NAME = "Community Home Assistant Add-ons Repository Updater"
-APP_VERSION = "1.1.0"
+APP_VERSION = "1.2.0"
 APP_DESCRIPTION = __doc__
 
 __version__ = APP_VERSION

--- a/repositoryupdater/cli.py
+++ b/repositoryupdater/cli.py
@@ -3,6 +3,7 @@ CLI Module.
 
 Handles CLI for the Repository Updater
 """
+import sys
 from os import environ
 from sys import argv
 
@@ -55,10 +56,10 @@ def git_askpass():
     """
     if argv[1] == "Username for 'https://github.com': ":
         print(environ["GIT_USERNAME"])
-        exit()
+        sys.exit()
 
     if argv[1] == "Password for 'https://" "%(GIT_USERNAME)s@github.com': " % environ:
         print(environ["GIT_PASSWORD"])
-        exit()
+        sys.exit()
 
-    exit(1)
+    sys.exit(1)

--- a/repositoryupdater/github.py
+++ b/repositoryupdater/github.py
@@ -8,7 +8,6 @@ functionality.
 from git import Repo
 from github import Github as PyGitHub
 from github import Repository
-from github.MainClass import DEFAULT_BASE_URL, DEFAULT_PER_PAGE, DEFAULT_TIMEOUT
 
 
 class GitHub(PyGitHub):
@@ -18,7 +17,9 @@ class GitHub(PyGitHub):
 
     def __init__(self, login_or_token=None):
         """Initialize a new GitHub object."""
-        super().__init__(login_or_token=login_or_token,)
+        super().__init__(
+            login_or_token=login_or_token,
+        )
         self.token = login_or_token
 
     def clone(self, repository: Repository, destination):

--- a/repositoryupdater/repository.py
+++ b/repositoryupdater/repository.py
@@ -140,6 +140,7 @@ class Repository:
             click.echo(crayons.cyan(f"Loading add-on {target}"))
             self.addons.append(
                 Addon(
+                    self.github,
                     self.git_repo,
                     target,
                     addon_config["image"],
@@ -186,7 +187,9 @@ class Repository:
             extensions=["jinja2.ext.loopcontrols"],
         )
 
-        with open(os.path.join(self.git_repo.working_dir, "README.md"), "w") as outfile:
+        with open(
+            os.path.join(self.git_repo.working_dir, "README.md"), "w", encoding="utf8"
+        ) as outfile:
             outfile.write(
                 jinja.get_template(".README.j2").render(
                     addons=addon_data,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-click==7.1.2
+click==8.0.1
 crayons==0.4.0
-emoji==0.6.0
-GitPython==3.1.12
-Jinja2==2.11.3
-PyGithub==1.54.1
-python-dateutil==2.8.1
-PyYAML==5.4
+emoji==1.6.0
+GitPython==3.1.24
+Jinja2==3.0.2
+PyGithub==1.55
+python-dateutil==2.8.2
+PyYAML==6.0
 semver==2.13.0

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,7 @@
 "Home Assistant add-ons repository updater setup."
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
-from repositoryupdater import (
-    APP_NAME,
-    APP_VERSION,
-    APP_DESCRIPTION,
-)
+from repositoryupdater import APP_DESCRIPTION, APP_NAME, APP_VERSION
 
 setup(
     name=APP_NAME,
@@ -32,20 +28,21 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3",
         "Topic :: Software Development :: Build Tools",
         "Topic :: Utilities",
     ],
     packages=find_packages(),
     install_requires=[
-        "click==7.1.2",
+        "click==8.0.1",
         "crayons==0.4.0",
-        "emoji==0.6.0",
-        "GitPython==3.1.12",
-        "Jinja2==2.11.3",
-        "PyGithub==1.54.1",
-        "python-dateutil==2.8.1",
-        "PyYAML==5.4",
+        "emoji==1.6.0",
+        "GitPython==3.1.24",
+        "Jinja2==3.0.2",
+        "PyGithub==1.55",
+        "python-dateutil==2.8.2",
+        "PyYAML==6.0",
         "semver==2.13.0",
     ],
     entry_points="""


### PR DESCRIPTION
# Proposed Changes

While this program is still an ugly piece of code, this PR adds some more to it 😬 

- Add support for YAML files as configuration files instead of JSON.
- Copy over the whole translation folder from the add-on (instead of just the English language file).

Additional:

- Update dependencies.
- Clones the add-on repo, reducing the API calls to GitHub
- Some other non-trival stuff
- Bump version