### PR TITLE
Fix loading remote add-on info from YAML

### DIFF
--- a/action/Dockerfile
+++ b/action/Dockerfile
@@ -10,7 +10,7 @@ RUN \
         --no-cache-dir \
         --prefer-binary \
         --find-links "https://wheels.home-assistant.io/alpine-3.14/amd64/" \
-        repository-updater==1.2.0
+        repository-updater==1.2.1
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN \
         --no-cache-dir \
         --prefer-binary \
         --find-links "https://wheels.home-assistant.io/alpine-3.14/amd64/" \
-        repository-updater==1.2.0
+        repository-updater==1.2.1
 
 # Entrypoint
 ENTRYPOINT ["repository-updater"]

--- a/repositoryupdater/__init__.py
+++ b/repositoryupdater/__init__.py
@@ -12,7 +12,7 @@ Home Assistant add-on repository approach.
 
 APP_NAME = "repository-updater"
 APP_FULL_NAME = "Community Home Assistant Add-ons Repository Updater"
-APP_VERSION = "1.2.0"
+APP_VERSION = "1.2.1"
 APP_DESCRIPTION = __doc__
 
 __version__ = APP_VERSION


### PR DESCRIPTION
# Proposed Changes

When loading up all add-on information in the repository, it should take into account the add-on might be using YAML.

It tries to figure it out by looking at the config files it has first... Before trying other files on the remote (this reduces GitHub API calls).

