### PR TITLE
Maintain order of options in the add-on Configuration tab

### DIFF
--- a/repositoryupdater/addon.py
+++ b/repositoryupdater/addon.py
@@ -334,7 +334,7 @@ class Addon:
                     separators=(",", ": "),
                 )
             else:
-                yaml.dump(config, outfile, default_flow_style=False)
+                yaml.dump(config, outfile, default_flow_style=False, sort_keys=False)
 
         click.echo(crayons.green("Done"))
 


### PR DESCRIPTION
# Proposed Changes

The Configuration tab of the add-ons shows the options in the same order as in the `config.yml` file.
Currently when regenerating the config file it is ordered by alphabetical order.
This change allows to keep the same order of presentation as the add-on creator originally intended.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/