### PR TITLE
Chore/add repo slug to addon templating data

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ list contains the following variables:
 - **description**: Description of the add-on
 - **url**: URL of the add-on
 - **repo**: URL to the add-on GitHub repo
+- **repo_slug**: add-on GitHub slug (:user/:repo)
 - **archs**: List of supported architectures by this add-on
 - **slug**: The add-on slug
 - **target**: The target directory of the add-on inside the add-ons repository

--- a/repositoryupdater/addon.py
+++ b/repositoryupdater/addon.py
@@ -440,6 +440,7 @@ class Addon:
         data["description"] = self.description
         data["url"] = self.url
         data["repo"] = self.addon_repository.html_url
+        data["repo_slug"] = self.addon_repository.full_name
         data["archs"] = self.archs
         data["slug"] = self.slug
         data["target"] = self.repository_target


### PR DESCRIPTION
# Proposed Changes

Adding the repo_slug on the addon templating data (the one used to fill the readme addon based on .README.j2)
Since we're all dealing with img.shields.io badges and this already handled in the [main readme rendering](https://github.com/hassio-addons/repository-updater/blob/618c846c33a2bdae0d1d0d11a36fcaad788ee8f1/repositoryupdater/repository.py#L200), this might be handy in the addon readme rendering as well.

## Related Issues

https://github.com/hassio-addons/repository-updater/discussions/149

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new variable in the add-on template that displays the GitHub repository identifier (user/repository), enhancing the clarity of the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->