### PR TITLE
Add fallback email address option

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -20,6 +20,9 @@ inputs:
   addon:
     description: (Deprecated) Use 'app' instead. Slug of the app to update the repository for
     required: false
+  email:
+    description: Email address used to write/commit to the target repo, required when the token is associated with a user that does not have a public email address
+    required: false
   force:
     description: Force repository update, even if no changes are detected
     default: "false"

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -17,6 +17,9 @@ elif [[ -n "${INPUT_ADDON:-}" ]]; then
   options+=(--app "${INPUT_ADDON}")
 fi
 
+[[ -n "${INPUT_EMAIL:-}" ]] \
+  && options+=(--email "${INPUT_EMAIL}")
+
 [[ "${INPUT_FORCE,,}" = "true" ]] \
   && options+=(--force)
 

--- a/repositoryupdater/cli.py
+++ b/repositoryupdater/cli.py
@@ -36,13 +36,18 @@ from .repository import Repository
     help="Update a single/specific app",
     metavar="<TARGET>",
 )
+@click.option(
+    "--email",
+    help="The email address to use for git commits",
+    metavar="<EMAIL>",
+)
 @click.option("--force", is_flag=True, help="Force an update of the app repository")
 @click.version_option(APP_VERSION, prog_name=APP_FULL_NAME)
-def repository_updater(token, repository, app, force):
+def repository_updater(token, repository, app, email, force):
     """Home Assistant Community Apps Repository Updater."""
     click.echo(crayons.blue(APP_FULL_NAME, bold=True))
     click.echo(crayons.blue("-" * 51, bold=True))
-    github = GitHub(token)
+    github = GitHub(token, email)
     click.echo(
         "Authenticated with GitHub as %s"
         % crayons.yellow(github.get_user().name, bold=True)

--- a/repositoryupdater/github.py
+++ b/repositoryupdater/github.py
@@ -15,12 +15,13 @@ class GitHub(PyGitHub):
 
     token: str
 
-    def __init__(self, login_or_token=None):
+    def __init__(self, login_or_token=None, fallback_email=None):
         """Initialize a new GitHub object."""
         super().__init__(
             login_or_token=login_or_token,
         )
         self.token = login_or_token
+        self.fallback_email = fallback_email
 
     def clone(self, repository: Repository, destination):
         """Clones a GitHub repository and returns a Git object."""
@@ -33,9 +34,11 @@ class GitHub(PyGitHub):
         repo = Repo.clone_from(repository.clone_url, destination, None, environ)
 
         config = repo.config_writer()
-        if self.get_user().email:
-            config.set_value("user", "email", self.get_user().email)
-        config.set_value("user", "name", self.get_user().name)
+        user = self.get_user()
+        email = user.email or self.fallback_email
+        if email:
+            config.set_value("user", "email", email)
+        config.set_value("user", "name", user.name)
         config.set_value("commit", "gpgsign", "false")
 
         return repo


### PR DESCRIPTION
# Proposed Changes

Allow the git user email address to be configured to allow accounts that use private email addresses to still use the tool.

## Related Issues

- #128 which had the same issue, but a different resolution
- #27 which is quite old, but seems to have had the same issue when the code base was a bit different

## Alternatives & Options to Consider

I implemented this quickly to get things working for me, but would like it to get into the main repo if possible to help others. A quick review may help decide if some of these options would be better design and/or usability:

- Change the name of the flag to something more specific, i.e. `--git-user-email`
- Allow the email to be provided via an environment variable rather than a command line flag
- Also allow the name of the git user to be set

# Proposed Changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional email parameter for commit author configuration that can be set via the GitHub Action input or CLI.
  * When provided, this email is used (or used as a fallback) for commit metadata so commits include the specified address.
  * Preserves existing behavior when no email is supplied; other commit settings remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->