### PR TITLE
fix: explicitly release GitConfigParser to prevent destructor error on Python 3.14

### DIFF
--- a/repositoryupdater/github.py
+++ b/repositoryupdater/github.py
@@ -37,5 +37,6 @@ class GitHub(PyGitHub):
             config.set_value("user", "email", self.get_user().email)
         config.set_value("user", "name", self.get_user().name)
         config.set_value("commit", "gpgsign", "false")
+        config.release()
 
         return repo


### PR DESCRIPTION
## Problem

In `repositoryupdater/github.py`, `config_writer()` is called on the cloned repo but the returned `GitConfigParser` object is never explicitly released via `config.release()`.

When `cleanup()` later runs `shutil.rmtree()` on the temp directory, the `GitConfigParser` object may still be alive in memory. Python 3.14's garbage collector then invokes `__del__` on it, which attempts to write to the already-deleted path, causing a `FileNotFoundError` and failing the workflow.

**Traceback observed:**
```
Exception ignored in: <gitdb.util.LazyMixin object at 0x...>
Traceback (most recent call last):
  File ".../gitpython/git/config.py", line ..., in __del__
    self.write()
  File ".../gitpython/git/config.py", line ..., in write
    ...
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/.../config'
```

## Fix

Call `config.release()` before returning from `clone()`. This explicitly flushes and closes the `GitConfigParser`, preventing its destructor from running after the temp directory is removed.

```python
config.set_value("commit", "gpgsign", "false")
config.release()  # <-- added

return repo
```

This follows the pattern recommended in the GitPython docs and is consistent with using `config_writer()` as a context manager.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Finalize git configuration after writing settings during cloning to prevent incomplete config state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->